### PR TITLE
Improve diff styling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion '21.1.2'
+    compileSdkVersion 23
+    buildToolsVersion '23.0.2'
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 21
+        targetSdkVersion 23
     }
 
     lintOptions {
@@ -16,7 +16,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:support-annotations:21.0.3'
+    compile 'com.android.support:support-annotations:23.1.1'
 }
 
 apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'

--- a/src/main/java/com/alorma/diff/lib/DiffLineSpan.java
+++ b/src/main/java/com/alorma/diff/lib/DiffLineSpan.java
@@ -1,0 +1,36 @@
+package com.alorma.diff.lib;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.graphics.Region;
+import android.text.style.LineBackgroundSpan;
+
+/**
+ * Line span used to highlight a diff change
+ */
+public class DiffLineSpan implements LineBackgroundSpan {
+    private static Rect mTmpRect = new Rect();
+    private final int color;
+    private final int padding;
+
+    public DiffLineSpan(int color, int padding) {
+        this.color = color;
+        this.padding = padding;
+    }
+
+    @Override
+    public void drawBackground(Canvas c, Paint p, int left, int right, int top, int baseline,
+                               int bottom, CharSequence text, int start, int end, int lnum) {
+        // expand canvas bounds by padding
+        Rect clipBounds = c.getClipBounds();
+        clipBounds.inset(- padding, 0);
+        c.clipRect(clipBounds, Region.Op.REPLACE);
+
+        final int paintColor = p.getColor();
+        p.setColor(color);
+        mTmpRect.set(left - padding, top, right + padding, bottom);
+        c.drawRect(mTmpRect, p);
+        p.setColor(paintColor);
+    }
+}

--- a/src/main/java/com/alorma/diff/lib/DiffTextView.java
+++ b/src/main/java/com/alorma/diff/lib/DiffTextView.java
@@ -19,6 +19,7 @@ public class DiffTextView extends TextView {
 
 	private int additionColor;
 	private int deletionColor;
+	private int infoColor;
 	private boolean showInfo;
 	private int maxLines = -1;
 
@@ -49,6 +50,7 @@ public class DiffTextView extends TextView {
 				R.styleable.DiffTextViewStyle, defStyleAttr, 0);
 		this.additionColor = array.getColor(R.styleable.DiffTextViewStyle_diff_addition_color, Color.parseColor("#CCFFCC"));
 		this.deletionColor = array.getColor(R.styleable.DiffTextViewStyle_diff_deletion_color, Color.parseColor("#FFDDDD"));
+		this.infoColor = array.getColor(R.styleable.DiffTextViewStyle_diff_info_color, Color.parseColor("#EEEEEE"));
 		this.showInfo = array.getBoolean(R.styleable.DiffTextViewStyle_diff_show_diff_info, false);
 		array.recycle();
 	}
@@ -83,11 +85,13 @@ public class DiffTextView extends TextView {
 							color = additionColor;
 						} else if (firstChar == '-') {
 							color = deletionColor;
+						} else if (token.startsWith("@@")) {
+							color = infoColor;
 						}
 
 						SpannableString spannableDiff = new SpannableString(token);
-						if (color == additionColor || color == deletionColor) {
-							BackgroundColorSpan span = new BackgroundColorSpan(color);
+						if (color == additionColor || color == deletionColor || color == infoColor) {
+							DiffLineSpan span = new DiffLineSpan(color, getPaddingLeft());
 							spannableDiff.setSpan(span, 0, token.length(), SpannableString.SPAN_EXCLUSIVE_EXCLUSIVE);
 						}
 

--- a/src/main/res/values/attrs.xml
+++ b/src/main/res/values/attrs.xml
@@ -9,6 +9,7 @@
         
         <attr name="diff_addition_color" format="color"/>
         <attr name="diff_deletion_color" format="color"/>
+        <attr name="diff_info_color" format="color" />
         <attr name="diff_show_diff_info" format="boolean"/>
 
     </declare-styleable>


### PR DESCRIPTION
This pull request greatly improves diff readability by:
* adding fullline color highlighting (done with the new `DiffLineSpan`)
* adding line color option for diff info (the `@@` part)

Here are two screenshots comparing the changes:
*Before the changes:*
![screenshot_2016-01-21-22-51-52](https://cloud.githubusercontent.com/assets/10142068/12495812/1efdf3d8-c092-11e5-8975-7fc65655fbe0.png)
*After the changes:*
![screenshot_2016-01-21-22-49-07](https://cloud.githubusercontent.com/assets/10142068/12495820/2ae9c23a-c092-11e5-9b7a-33f1e9ba19fd.png)
