### PR TITLE
Add text color customization

### DIFF
--- a/src/main/java/com/alorma/diff/lib/DiffTextView.java
+++ b/src/main/java/com/alorma/diff/lib/DiffTextView.java
@@ -8,6 +8,7 @@ import android.os.Build;
 import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
+import android.text.style.ForegroundColorSpan;
 import android.util.AttributeSet;
 import android.widget.TextView;
 
@@ -16,6 +17,9 @@ public class DiffTextView extends TextView {
 	private int additionColor;
 	private int deletionColor;
 	private int infoColor;
+	private int additionTextColor;
+	private int deletionTextColor;
+	private int infoTextColor;
 	private boolean showInfo;
 	private int maxLines = -1;
 
@@ -47,6 +51,9 @@ public class DiffTextView extends TextView {
 		this.additionColor = array.getColor(R.styleable.DiffTextViewStyle_diff_addition_color, Color.parseColor("#CCFFCC"));
 		this.deletionColor = array.getColor(R.styleable.DiffTextViewStyle_diff_deletion_color, Color.parseColor("#FFDDDD"));
 		this.infoColor = array.getColor(R.styleable.DiffTextViewStyle_diff_info_color, Color.parseColor("#EEEEEE"));
+		this.additionTextColor = array.getColor(R.styleable.DiffTextViewStyle_diff_addition_text_color, Color.TRANSPARENT);
+		this.deletionTextColor = array.getColor(R.styleable.DiffTextViewStyle_diff_deletion_text_color, Color.TRANSPARENT);
+		this.infoTextColor = array.getColor(R.styleable.DiffTextViewStyle_diff_info_text_color, Color.TRANSPARENT);
 		this.showInfo = array.getBoolean(R.styleable.DiffTextViewStyle_diff_show_diff_info, false);
 		array.recycle();
 	}
@@ -76,18 +83,28 @@ public class DiffTextView extends TextView {
 
 						char firstChar = token.charAt(0);
 
-						int color = 0;
+						int color = Color.TRANSPARENT;
+						int textColor = Color.TRANSPARENT;
 						if (firstChar == '+') {
 							color = additionColor;
+							textColor = additionTextColor;
 						} else if (firstChar == '-') {
 							color = deletionColor;
+							textColor = deletionTextColor;
 						} else if (token.startsWith("@@")) {
 							color = infoColor;
+							textColor = infoTextColor;
 						}
 
 						SpannableString spannableDiff = new SpannableString(token);
-						if (color == additionColor || color == deletionColor || color == infoColor) {
+						// Span for line color (where transparent is considered as default)
+						if (color != Color.TRANSPARENT) {
 							DiffLineSpan span = new DiffLineSpan(color, getPaddingLeft());
+							spannableDiff.setSpan(span, 0, token.length(), SpannableString.SPAN_EXCLUSIVE_EXCLUSIVE);
+						}
+						// Span for text color (where transparent is considered as default)
+						if (textColor != Color.TRANSPARENT) {
+							ForegroundColorSpan span = new ForegroundColorSpan(textColor);
 							spannableDiff.setSpan(span, 0, token.length(), SpannableString.SPAN_EXCLUSIVE_EXCLUSIVE);
 						}
 

--- a/src/main/res/values/attrs.xml
+++ b/src/main/res/values/attrs.xml
@@ -10,6 +10,9 @@
         <attr name="diff_addition_color" format="color"/>
         <attr name="diff_deletion_color" format="color"/>
         <attr name="diff_info_color" format="color" />
+        <attr name="diff_addition_text_color" format="color"/>
+        <attr name="diff_deletion_text_color" format="color"/>
+        <attr name="diff_info_text_color" format="color" />
         <attr name="diff_show_diff_info" format="boolean"/>
 
     </declare-styleable>


### PR DESCRIPTION
I've come to do this sooner than I had expected, so here it is :smile: 
As you requested in PR #2 there are now options to customize the text color of different diff lines. The following attributes have been added:
* `diff_addition_text_color`
* `diff_deletion_text_color`
* `diff_info_text_color`

Here's a screenshot that makes use of those changes:
![screenshot_2016-01-22-11-32-12](https://cloud.githubusercontent.com/assets/10142068/12508442/34e94052-c0fc-11e5-88e5-169f0905d815.png)
